### PR TITLE
Add sequential processing with interrupt and progress

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -18,7 +18,11 @@
         <div class="form-group">
             <textarea class="form-control mb-2" rows="5" data-bind="value: current" placeholder="Type your message [REQUEST]"></textarea>
             <textarea class="form-control mb-2" rows="5" data-bind="value: requests" placeholder="Requests"></textarea>
-            <button class="btn btn-primary" data-bind="click: send">Send</button>
+            <button class="btn btn-primary mr-2" data-bind="click: send, enable: !sending()">Send</button>
+            <button class="btn btn-warning" data-bind="click: interrupt, enable: sending">Interrupt</button>
+            <div class="progress mt-2" data-bind="visible: sending">
+                <div class="progress-bar" role="progressbar" style="width: 0%" data-bind="style: { width: progress() + '%' }, text: progress() + '%' "></div>
+            </div>
         </div>
 
 

--- a/src/test/webapp/tests.js
+++ b/src/test/webapp/tests.js
@@ -16,3 +16,43 @@ QUnit.test('collectResponses joins llama messages', function(assert) {
     ];
     assert.equal(collectResponses(msgs), 'one\ntwo');
 });
+
+QUnit.test('runSequentially processes prompts sequentially', function(assert) {
+    var done = assert.async();
+    var calls = [];
+    var d1 = $.Deferred();
+    var d2 = $.Deferred();
+    function sendFn(p) {
+        calls.push(p);
+        return calls.length === 1 ? d1 : d2;
+    }
+    var progress = [];
+    runSequentially(['A', 'B'], sendFn, function(c, t) { progress.push(c + '/' + t); }, function() { return false; }, function() {
+        assert.deepEqual(calls, ['A', 'B']);
+        assert.deepEqual(progress, ['1/2', '2/2']);
+        done();
+    });
+    assert.deepEqual(calls, ['A']);
+    d1.resolve();
+    setTimeout(function() {
+        assert.deepEqual(calls, ['A', 'B']);
+        d2.resolve();
+    }, 0);
+});
+
+QUnit.test('runSequentially stops when interrupted', function(assert) {
+    var done = assert.async();
+    var calls = [];
+    var d1 = $.Deferred();
+    function sendFn(p) {
+        calls.push(p);
+        return d1;
+    }
+    var cancel = false;
+    runSequentially(['A', 'B'], sendFn, null, function() { return cancel; }, function() {
+        assert.deepEqual(calls, ['A']);
+        done();
+    });
+    d1.resolve();
+    cancel = true;
+});


### PR DESCRIPTION
## Summary
- process prompts sequentially to avoid multiple concurrent requests
- add interrupt button and progress bar to the chat page
- expose `runSequentially` helper function
- extend QUnit tests for new helper

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6865e4390564832ba300dd206e765321