### PR TITLE
Fix Models button output

### DIFF
--- a/src/main/webapp/scripts/chat.js
+++ b/src/main/webapp/scripts/chat.js
@@ -25,6 +25,13 @@ function collectResponses(messages) {
     }).join('\n');
 }
 
+function formatData(data) {
+    if (typeof data === 'object') {
+        return JSON.stringify(data, null, 2);
+    }
+    return data;
+}
+
 function runSequentially(prompts, sendFn, progressFn, isInterrupted, doneFn) {
     var total = prompts.length;
     var index = 0;
@@ -129,7 +136,7 @@ function LlamaViewModel() {
 
     self.listModels = function () {
         listModels().done(function (data) {
-            alert(data);
+            alert(formatData(data));
         }).fail(function () {
             alert('Failed to list models');
         });

--- a/src/test/webapp/tests.js
+++ b/src/test/webapp/tests.js
@@ -85,3 +85,12 @@ QUnit.test('pullLlama3 uses POST', function(assert) {
     assert.deepEqual(data, { name: 'llama3:8b' });
     $.post = orig;
 });
+
+QUnit.test('formatData converts objects to string', function(assert) {
+    var obj = { a: 1 };
+    assert.equal(formatData(obj), JSON.stringify(obj, null, 2));
+});
+
+QUnit.test('formatData leaves strings unchanged', function(assert) {
+    assert.equal(formatData('x'), 'x');
+});


### PR DESCRIPTION
## Summary
- stringify objects returned from listModels
- add tests for the new formatting helper

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_687af93370ec832b911f68311d5e5b8b